### PR TITLE
perf: ⚡ merge homepage JSON-LD schemas into a single @graph

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -471,6 +471,38 @@ export default function IndexPage({ clients, steps }: IndexPageProps) {
     ],
   };
 
+  const combinedSchema = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: breadcrumbSchema.itemListElement,
+      },
+      {
+        '@type': 'Organization',
+        name: organizationSchema.name,
+        url: organizationSchema.url,
+        foundingDate: organizationSchema.foundingDate,
+        description: organizationSchema.description,
+        knowsAbout: organizationSchema.knowsAbout,
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: faqSchema.mainEntity,
+      },
+      {
+        '@type': 'WebSite',
+        name: webSiteSchema.name,
+        url: webSiteSchema.url,
+        description: webSiteSchema.description,
+      },
+      {
+        '@type': 'ItemList',
+        itemListElement: siteNavigationSchema.itemListElement,
+      },
+    ],
+  };
+
   return (
     <>
       <Head>
@@ -488,29 +520,7 @@ export default function IndexPage({ clients, steps }: IndexPageProps) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(breadcrumbSchema),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(organizationSchema),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(webSiteSchema),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(siteNavigationSchema),
+            __html: JSON.stringify(combinedSchema),
           }}
         />
       </Head>

--- a/plans/README.md
+++ b/plans/README.md
@@ -21,7 +21,7 @@ Execute in the order below unless dependencies say otherwise. Each executor: rea
 | 007  | Fix homepage `setInterval(1000ms)` causing whole-page re-renders             | P1       | S      | —          | DONE — commit `3874a8a` on branch `advisor/007-isolate-homepage-time-widget`, awaiting operator merge |
 | 008  | Inline Inter font in OG handlers (remove jsdelivr fetch)                     | P2       | S      | —          | TODO                                                                                                  |
 | 009  | Replace lone lodash barrel import in `banner-preview`                        | P3       | S      | —          | TODO                                                                                                  |
-| 010  | Merge 5 JSON-LD `<script>` blocks into a single `@graph`                     | P3       | S      | —          | TODO                                                                                                  |
+| 010  | Merge 5 JSON-LD `<script>` blocks into a single `@graph`                     | P3       | S      | —          | DONE — branch `advisor/010-merge-homepage-jsonld`, awaiting operator merge                            |
 | 011  | Delete dead pages: `welcome.tsx` (Kid-GO) and `live.tsx` (placeholder ID)    | P3       | S      | —          | TODO                                                                                                  |
 | 012  | Add `.env.example` + initial `CLAUDE.md` + remove root cruft                 | P2       | S      | —          | TODO                                                                                                  |
 


### PR DESCRIPTION
## Summary

- Combines 5 separate `<script type=\"application/ld+json\">` blocks on the homepage (BreadcrumbList, Organization, FAQPage, WebSite, ItemList) into one `@graph`-wrapped block.
- Reuses the existing schema objects' data fields — no structured-data drift.
- Closes plan [`010`](../blob/advisor/010-merge-homepage-jsonld/plans/010-merge-jsonld-scripts.md).

## Why

Each separate `<script>` adds an extra HTML element and an extra JSON parse for Google's crawler. JSON-LD's official `@graph` construct exists for exactly this case. Google treats the merged form identically (per their structured-data nesting docs). Saves a few hundred bytes on every homepage render and is easier to debug with Google's Rich Results test.

## Test plan

- [x] `curl -s http://localhost:4200/ | grep -c \"application/ld+json\"` returns `1` (was `5`)
- [x] Rendered HTML contains `\"@graph\":[` and all 5 entity types (BreadcrumbList / Organization / FAQPage / WebSite / ItemList)
- [x] `yarn typecheck` exits 0
- [x] `yarn build` exits 0
- [ ] Post-deploy: validate with https://search.google.com/test/rich-results

Lint/test skipped — pre-existing failures tracked in plans 014/015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)