### PR TITLE
docs: 📈 12-month marketing plan v1

### DIFF
--- a/docs/marketing/plan.md
+++ b/docs/marketing/plan.md
@@ -1,0 +1,812 @@
+# weshipit.today — Marketing Plan v1
+
+**Prepared by:** Claude (fCMO planning session)
+**For:** David Leuliette & Matthys — weshipit.today
+**Date:** 2026-07-10
+**Status:** v1 — approved section-by-section by David, 2026-07-09/10
+
+---
+
+## 1. Executive summary
+
+**This plan optimizes one number: the share of weshipit.today's revenue that doesn't consume founder hours — from ~5–10% today to 20–25% in 12 months — on a marketing budget of less than 4 hours per week and €0 new spend.**
+
+weshipit.today is a profitable two-person React Native studio (David Leuliette + Matthys) doing €5–15K/mo, ~90% of it tied to delivery hours, with a hard capacity ceiling around €25K/mo. The research phase found a business that has already built almost everything it needs — a 49-tool directory, a 100+ term glossary, a 25-episode podcast with enterprise French guests, a proven affiliate SEO cluster, a book, a bootcamp platform, and an email list — but scattered across two un-linked domains, with zero email capture on the main site and zero attribution on what actually produces clients.
+
+### Three big bets, ranked by leverage
+
+**Bet 1 — Consolidate three properties into one system.** davidl.fr (freelance-era personal site) holds the business's only email list, its blog, and its entire product inventory — and competes with weshipit.today for the same offers. The plan makes davidl.fr the audience layer, weshipit.today the commercial layer, and the FR affiliate cluster the playbook both follow. Cheapest bet in the plan; pure unlock.
+
+**Bet 2 — Build the connective tissue: capture → nurture → launch.** Migrate the list Mailchimp → MailerLite, put one lead magnet (the React Native Stability Checklist) on the high-traffic content pages, run a simple welcome sequence and monthly digest. Every future move in the plan — book relaunch, bootcamp relaunch, affiliate pushes — depends on this audience asset existing.
+
+**Bet 3 — Relaunch what already exists instead of building new.** The book (Q2) and bootcamp (Q3) get real launches at the owned audience for the first time; the tools directory gets partner/affiliate links; the Incubateur cluster gets finished. Product revenue answers the year's central question with data: which hours-decoupled line — products or affiliate — deserves year 2.
+
+### What twelve months plausibly looks like
+
+- Product + affiliate = 20–25% of monthly revenue; total revenue ≥ €15K/mo without added delivery hours
+- Attribution answered: booked calls by source and blended CAC per channel, known for the first time
+- The list is the #1 launch channel by attributable revenue; retainers stable as the funded floor
+- Two visible revenue step-functions (book, bootcamp) rather than a promised hockey stick
+
+### 90-day priorities
+
+1. Wire conversion events (Cal.com, affiliate, forms) — end "I don't really know" permanently
+2. Migrate Mailchimp → MailerLite; cancel Mailchimp
+3. Ship the merged SEO branches + janitor pass; finish the Incubateur cluster (témoignages + hub)
+4. Stability Checklist capture live on tools/glossary/podcast pages, with welcome sequence
+5. Monthly client recaps + testimonial harvest + the quarterly referral ask
+6. Pricing decision gate: book price, bootcamp format, Maestro public fee — unblocks the Q2 relaunch
+
+Execution runs on the agentic stack already proven in this repo (the June SEO sprint: 8 plans, audit-to-merged in two weeks) — David decides and touches clients; agents produce the rest.
+
+---
+
+## 2. Strategic frame
+
+### What weshipit.today is, in one sentence
+
+weshipit.today is the commercial home of a two-person React Native studio (David Leuliette + Matthys) — an expertise brand built since 2016 that currently monetizes through high-touch retainers, and that this plan re-points toward productized, hours-decoupled revenue.
+
+### The three-property reality (named, not glossed)
+
+| Property                                      | Today                                                                                                                                      | Role in this plan                                                                                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **weshipit.today (EN)**                       | Company site: retainers €2.5–5K/mo, €10K audit, testing, consulting + free-tools moat (49 tools, 100+ glossary terms, 25 podcast episodes) | **The commercial layer.** All offers — services AND products — live and are bought here                                                                           |
+| **davidl.fr**                                 | Freelance-era personal site: "hire me" hero, blog, Mailchimp newsletter, book, bootcamp, workshop platform, testimonials                   | **The audience layer.** David's personal brand: blog, talks, newsletter, credibility — every CTA funnels to weshipit.today. Retire the competing "hire me" offers |
+| **FR affiliate cluster** (on weshipit domain) | Incubateur Solopreneur pages, keyword-mapped, 4/5 spokes live                                                                              | **The proven playbook.** The template to replicate on the RN side: cluster → trust page → conversion page → revenue with zero delivery hours                      |
+
+The core structural move of the whole plan: **stop running three disconnected properties; run one system — davidl.fr builds the audience, weshipit.today converts it, the affiliate playbook shows how.** Concretely: cross-link the domains, repoint davidl.fr's coaching/consultation to weshipit.today equivalents (one front door per offer), and migrate the newsletter into a shared asset.
+
+### The category we're claiming
+
+Not "React Native agency" — agencies compete on headcount and day rates. The claim: **"the React Native stability experts."** Weekly bugs cause 40% of users to uninstall; we're who you subscribe to when that's you. Pause/cancel anytime, in your GitHub within 48h — positioned against agencies (lengthy contracts) and hiring (slow, risky). Productization extends the same claim: package the _diagnosis_ (audit), the _method_ (Maestro testing, bootcamp, book), and the _knowledge_ (tools, glossary, podcast).
+
+### Who we're for (ICP, distilled)
+
+**Buying ICP (services + dev products):**
+
+- CTO / eng lead / founder with a React Native app **in production**, 10K+ users
+- Stated problem: bugs, crashes, slow releases. Real problem: retention bleeding and no in-house diagnosis capability
+- Can sign €2.5–10K without procurement; French enterprise-adjacent is the proven wedge (Alan, Cdiscount, Swan on the podcast)
+- Buys **certainty from a named expert**, not hours
+- Secondary tier: individual RN devs (bootcamp, book, workshop — lower price, list-building value)
+
+**Audience ICP (FR affiliate):**
+
+- French **dev solopreneurs** — builders who get 10x from the Incubateur's tech Sprints (CustomGPTs, IA, automation, SaaS solo); first-class persona, not an afterthought
+
+### The business-model logic
+
+Today: €5–15K/mo, ~90% tied to founder hours, capacity-capped at ~5 retainers, attribution unknown. The compounding thesis: **the content assets already attract both ICPs, and the product assets already exist — what's missing is the connective tissue** (capture → nurture → productized offer) and it must run on < 4h/week of David's time. Retainers stay the floor; productized + affiliate revenue becomes the growth line, because those euros don't consume delivery capacity.
+
+### Brand voice (non-negotiables)
+
+1. **Numbers over adjectives** — "40% uninstall," "48 hours," never "world-class."
+2. **Honest reviews convert** — the 4.6/5 review names cons; the vs-page recommends the competitor where genuinely better. This is Funnel B's moat; keep it.
+3. **Explain the product before the offer** (rule established 2026-07-01) — every bottom-funnel hero says _what it is_ and _who it's for_ before the price; full product name in the H1.
+4. **Developer-credible, never salesy** — GitHub receipts, Stack Overflow rank, real code examples.
+5. **FR warm and direct (tutoiement); EN sharp and metric-led.**
+6. **Company, not freelancer** — "we," David + Matthys. The "hire me" era ends with this plan; davidl.fr speaks as a person, weshipit.today sells as a company.
+
+**Confirmed decisions (2026-07-09):** (1) davidl.fr becomes audience-only — its commercial offers repoint to weshipit.today; (2) the FR affiliate arm is a template to invest in, not a side project to contain.
+
+---
+
+## 3. Current state
+
+### Team composition (marketing surface area)
+
+| Person          | Role           | Marketing surface area                                                                                                                                          |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| David Leuliette | Founder        | Everything: positioning, all content (podcast, SEO pages, affiliate cluster), sales calls, socials (@flexbox\_, YouTube, GitHub), plus Enterprise-tier delivery |
+| Matthys         | Lead developer | Delivery only; no marketing surface today                                                                                                                       |
+
+**Honest read:** marketing has exactly one owner, and he's also the top delivery resource and the sales team. David is π-shaped (deep dev + deep content/SEO) — which is why the asset base is so strong — but at < 4h/week, the binding constraint is founder attention, not skill. No hire is affordable or needed at this stage; the plan's answer is ruthless scope + agentic tooling (§11), with one cheap unlock to consider in Q2: a VA/editor contractor a few hours a week for podcast post-production and content repurposing.
+
+### Marketing budget (current)
+
+- Paid acquisition: €0
+- Tooling: Prismic, Vercel, Cal.com, Airtable, Mailchimp (davidl.fr), podcast hosting (Anchor/Spotify) — roughly €100–200/mo, mostly already sunk
+- Retainers/agencies/headcount: none
+- Founder time: **< 4h/week** (delivery-first — this is the real budget)
+- Blended CAC: **unknown** — attribution is genuinely unmeasured ("referrals… I don't really know"). Top open decision in §13.
+- Funding-stage tier: bootstrapped/organic-only. Implication: the 90-day plan must produce results with zero new spend and near-zero new founder hours — automation and consolidation, not new channels.
+
+### Phase of growth
+
+€5–15K/mo ≈ $60–180K ARR-equivalent — the "treacherous middle" for a services business, with a twist: retainer revenue is capacity-capped at roughly ~€25K/mo for a 2-person team, so "growth" through more retainers has a visible ceiling. That's exactly why the productize priority is right: the next S-curve isn't more clients, it's revenue per founder-hour.
+
+### What's already done (acknowledge, then build on)
+
+| Asset                                                                                                                                             | Status                                    | Marketing leverage                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
+| 49-tool React Native directory + per-tool pages                                                                                                   | Live, freshly SEO-optimized               | Top-of-funnel magnet for the buying ICP; capture point candidate #1                  |
+| 100+ term glossary                                                                                                                                | Live (Prismic)                            | Long-tail SEO; internal-link fabric                                                  |
+| Le Cross Platform Show — 25 FR episodes (Alan, Cdiscount, Swan)                                                                                   | Live, ~1.5/mo                             | Authority with French enterprise; guest network = warm B2B pipeline nobody is mining |
+| Incubateur affiliate cluster (4 pages, keyword-mapped, tracking plan)                                                                             | Live since 2026-07-01                     | Proven zero-hours revenue playbook; template for RN-side clusters                    |
+| June–July 2026 SEO sprint (8 plans: schema, meta, links, crawl hygiene)                                                                           | Executed                                  | Technical SEO debt largely paid down                                                 |
+| davidl.fr: book, bootcamp, workshop platform w/ certification, 9 courses, EAS cheatsheet, Mailchimp list, 8+ testimonials, 10 podcast appearances | Live but scattered, freelance-era framing | **The productization seed inventory** — nothing needs building from scratch          |
+| llms.txt, hreflang EN/FR, OG generation, JSON-LD coverage                                                                                         | Live                                      | AI-search and technical foundation ahead of most peers                               |
+| 400+ devs trained; top-20 Stack Overflow RN contributor                                                                                           | Historical                                | Credibility anchors, under-used on sales surfaces                                    |
+
+### What's in-flight (drafted but not shipped)
+
+| Item                                              | Status                           | Blocker                                     |
+| ------------------------------------------------- | -------------------------------- | ------------------------------------------- |
+| SEO plan branches 003–008                         | Done on branches, not all merged | Just needs merge + deploy — days, not weeks |
+| `/temoignages-incubateur-solopreneur` (UGC spoke) | Planned in cluster doc           | Founder time                                |
+| `/incubateur-solopreneur` hub pillar              | Planned                          | Founder time                                |
+
+### What's stuck (and needs to unstick this quarter)
+
+| Issue                                                                                         | Cost of inaction                                                               | Action                                                                                                      |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Zero attribution — nobody knows what produces clients                                         | Every marketing hour is unguided; can't tell if SEO sprint worked              | Wire conversion events (Cal.com bookings, affiliate clicks, form submits) into Vercel Analytics — Weeks 1–2 |
+| No email capture on weshipit.today; Mailchimp list marooned on davidl.fr                      | The whole content moat leaks; productized offers will have nobody to launch to | One capture offer on high-traffic pages; unify list — Weeks 1–4                                             |
+| davidl.fr competes with weshipit.today (duplicate offers, zero cross-links, split authority)  | Cannibalized SEO, confused warm referrals, "freelancer" undercuts "company"    | Repoint offers, cross-link, reframe hero — Weeks 3–4                                                        |
+| Stale surfaces (`home.tsx`, `qr.tsx`, `devtools.tsx`, dead Slack invite, legacy Gumroad link) | Minor, but erodes credibility with the exact ICP that notices details          | Janitor pass — Week 1                                                                                       |
+
+### Audit rubric snapshot (scored from materials, 2026-07-09)
+
+| #   | Section               | Score | Note                                                                                      |
+| --- | --------------------- | ----- | ----------------------------------------------------------------------------------------- |
+| 1   | Positioning           | 3     | Clear on weshipit ("subscription RN dev"); diluted by three-property split                |
+| 2   | Customer research     | 2     | Founder intuition + client proximity; no research artifacts                               |
+| 3   | Homepage              | 3     | Strong problem-agitation hero, pricing, FAQ; zero email capture; orphan `home.tsx`        |
+| 4   | Sales / product pages | 4     | Every tier + audit + testing + consulting + retreat has a page                            |
+| 5   | Conversion pages      | 3     | Affiliate cluster excellent; RN side lacks campaign/use-case landers                      |
+| 6   | Competitor comparison | 2     | One vs-page (affiliate side); nothing for RN consulting (vs agency / vs hiring)           |
+| 7   | Resources / content   | 4     | Tools + glossary + podcast + davidl.fr blog = moat-in-progress                            |
+| 8   | Onboarding            | 2     | High-touch, 48h promise; nothing automated or documented                                  |
+| 9   | Email lifecycle       | 1     | Mailchimp newsletter on davidl.fr only; no flows; list size unknown                       |
+| 10  | Sales material        | 2     | Site is the deck; logos + davidl.fr testimonials but no written case studies              |
+| 11  | Messaging             | 3     | Distinctive founder voice; not documented; "freelancer vs company" inconsistency          |
+| 12  | Pricing               | 3     | Clear public tiers + scarcity; LTV math unknown                                           |
+| 13  | CRO                   | 1     | Vercel Analytics only; no conversion events, no tests                                     |
+| 14  | GTM launches          | 2     | Podcast ships regularly; no launch motion (book/bootcamp never launched _at_ an audience) |
+| 15  | Ads (paid)            | 0     | None — stage-appropriate, not a weakness                                                  |
+| 16  | SEO                   | 3     | Active clusters, strong schema; DR/traffic numbers unknown                                |
+| 17  | Internationalization  | 3     | Genuinely bilingual EN/FR with hreflang — rare strength                                   |
+
+**Total: 41/85 (48%).** Shape: strong on owned content assets and sales-page surface (#4, #5, #7, #16), near-zero on capture, lifecycle, and measurement (#9, #13, #2, #10). Traffic machinery exists; relationship machinery is scattered across two un-linked domains. The plan's center of gravity: consolidation, capture → lifecycle, and relaunching existing-but-buried product assets — which is why §5 (Activation) and §6 (Retention) carry the most new work.
+
+_Open data to backfill: Mailchimp list size; organic traffic on tools/glossary pages (Vercel Analytics / GSC)._
+
+---
+
+## 4. Acquisition
+
+_How strangers become aware of weshipit.today. Constraint applied throughout: < 4h/week, €0 new spend, so every move either compounds (SEO, repurposing) or mines assets that already exist (podcast guests, glossary traffic)._
+
+### Current state
+
+Organic-only, and it's already the right mix for this stage: SEO (tools directory, glossary, affiliate cluster — freshly optimized), the podcast (25 episodes, enterprise-grade French guests), founder socials (@flexbox\_, YouTube, GitHub), and word-of-mouth. What's missing isn't a channel — it's (a) measurement (nobody knows which of these produces clients), (b) commercial-intent SEO on the RN side (the traffic pages are informational; the money pages have no keyword clusters around them), and (c) LinkedIn, where the buying ICP (CTOs, eng leads) actually lives — David is invisible there while being strong on Twitter/X, which skews individual-dev.
+
+### The plan
+
+**Move 1 — Measurement before acquisition (Week 1, then permanent).** You can't run acquisition on "I don't really know." Wire custom events into Vercel Analytics on every conversion: Cal.com clicks (`weshipit-onboarding`, `coaching`), affiliate-link clicks, Airtable/Notion form submits, newsletter signups. Add GSC review to the monthly routine. From then on, every acquisition decision gets judged by booked-calls-by-source, not vibes. _Skills: `analytics`. Tools: Vercel Analytics custom events, Google Search Console, `claude-seo:seo-google` agent._
+
+**Move 2 — Ship the SEO already sitting on branches (Week 1).** Merge plans 003–008, deploy, request re-indexing. Zero new work, pure unlock.
+
+**Move 3 — Replicate the cluster playbook on the RN money pages (Q1–Q2).** The Incubateur cluster is the proven template: keyword-map → spokes → internal-link matrix → conversion page. Run it twice on the EN side, where each converted visitor is worth €2.5–10K:
+
+- **Audit cluster:** "react native audit," "react native performance audit," "react native code review" → spokes feeding `/audit` and the €10K Kickstart.
+- **"vs" cluster (also sales enablement):** "react native agency vs freelancer," "hire react native developer vs agency," "outsource react native development" → honest comparison pages in the same voice as the vs-Marketing-Mania page, each ending at the subscription pitch.
+  One page every two weeks — cadence over volume. _Skills: `programmatic-seo`, `seo-audit`, copy patterns from the affiliate cluster. Tools: `claude-seo:seo-cluster` agent, GSC._
+
+**Move 4 — Finish the Incubateur cluster (Q1).** Build `/temoignages-incubateur-solopreneur` and the `/incubateur-solopreneur` hub pillar per the existing cluster doc. The cluster is 80% built; the hub is what makes the spokes rank. Small push at each Incubateur cohort/launch window. _Skills: `ai-seo` (highly LLM-citable pages). Tools: existing cluster-doc tracking plan._
+
+**Move 5 — Mine the podcast instead of just publishing it (Q1–Q4).** Three leverages, near-zero founder time: (a) **transcripts** — infrastructure exists (`/podcast/[slug]/transcript`); publishing turns 25 episodes into 25 long-form SEO/AI-citable pages; (b) **guests are pipeline** — every guest is a CTO/lead running React Native at scale; a post-episode thank-you + "here's our audit if your team ever needs eyes" is warm outbound that doesn't feel like outbound; (c) **clips** — one quote-card or clip per episode, scheduled to X + LinkedIn. First thing to hand a VA/editor in Q2. _Skills: `social`, `video`. Tools: transcript pipeline, post scheduler._
+
+**Move 6 — LinkedIn presence, minimum viable (Q2).** Not a content treadmill: repurpose. Podcast clips, one lesson per client engagement (anonymized), French enterprise RN angle. 2 posts/week, batched monthly. It's the only channel where the €2.5–10K buyer scrolls. _Skills: `social`._
+
+**Move 7 — Directory + AI-search layer (Q1, one-time).** Submit the tools directory/glossary/EAS cheatsheet to dev-tool directories and RN newsletters (pitch This Week in React once); extend llms.txt. One afternoon, long-tail payoff. _Skills: `directory-submissions`, `ai-seo`._
+
+**Move 8 — Paid: skipped, with reason.** No budget, no attribution baseline, high-ACV sales motion with capacity ceiling — paid solves a problem this business doesn't have yet. Revisit only if a productized offer shows organic conversion worth amplifying, and not before attribution works.
+
+### 90-day acquisition moves
+
+| Weeks | Ship                                                                                                                |
+| ----- | ------------------------------------------------------------------------------------------------------------------- |
+| 1–2   | Conversion events live; SEO branches merged + deployed; janitor pass on stale surfaces                              |
+| 3–4   | Témoignages spoke live; first podcast transcripts published; directory submissions done                             |
+| 5–8   | Incubateur hub pillar live; audit-cluster keyword map + first spoke; guest-outreach note sent to all 25 past guests |
+| 9–12  | Second audit-cluster spoke; first "vs" page; clip cadence running; first monthly GSC/attribution review             |
+
+### 12-month outlook
+
+- **Q1:** measurement live, in-flight SEO shipped, Incubateur cluster complete.
+- **Q2:** audit + vs clusters ranking; transcripts indexed; LinkedIn cadence via VA; podcast guest pipeline producing 1–2 audit conversations.
+- **Q3:** RN clusters mature into the same shape as the Incubateur cluster (hub + spokes + conversions tracked); AI-search citations measurable.
+- **Q4:** attribution history rich enough to name blended CAC per channel — the number that's unknowable today.
+
+### Skills + tools
+
+- **Skills:** `analytics`, `programmatic-seo`, `seo-audit`, `ai-seo`, `directory-submissions`, `social`, `video`
+- **Tools/agents:** Vercel Analytics custom events, Google Search Console, `claude-seo` agent suite (cluster, technical, geo), transcript pipeline, post scheduler
+
+**Decision noted at approval:** LinkedIn in; YouTube stays passive (repurposing only).
+
+---
+
+## 5. Activation
+
+_Once someone finds you, do they have an experience that converts? For this business "activation" means three distinct conversions: a visitor becomes an email subscriber, a prospect becomes a booked call, and a signed client becomes a delighted reference. All three exist informally today; none is instrumented or designed._
+
+### Current state
+
+The only activation machinery is a Cal.com button and David's own responsiveness. It clearly works when the lead is warm (referrals convert), but: content traffic has **no next step short of "book a call"** — a huge ask for someone who just looked up a glossary term; the EAS cheatsheet gives away email-capture value for free (no gate, on the wrong site); the newsletter lives on davidl.fr (Mailchimp) while the traffic lives on weshipit.today; and the strongest activation asset — the 48h-to-first-code onboarding — exists only as a claim, not a documented experience. The affiliate funnel is the exception: avis → code-reduction → payment is a designed path with the hero rule applied.
+
+### The plan
+
+**Move 1 — Migrate the list: Mailchimp → MailerLite (Weeks 1–2, before any new capture is built).** The existing list lives on Mailchimp via davidl.fr; the decision (2026-07-10) is MailerLite — a simple funnel tool, not a feature warehouse. Do the migration _first_ so nothing new gets built on the legacy ESP: export subscribers + unsubscribes from Mailchimp, import to MailerLite, authenticate the sender domain (SPF/DKIM), rewrite the one integration point (`api/newsletter.ts`) against the MailerLite API, and set up a single welcome automation. Then cancel Mailchimp. Half a day of work while the list is small — every month of delay makes it bigger. _Tools: MailerLite API, existing `api/newsletter.ts` as the only code touchpoint._
+
+**Move 2 — One capture offer, everywhere the traffic already is (Weeks 2–4).** Create a single email-capture asset aimed at the buying ICP and place it on the highest-traffic surfaces (tools index + detail pages, glossary, podcast pages). Strongest candidate, minimal new work: **"The React Native Stability Checklist"** — the pre-audit checklist distilled from the Kickstart methodology (chosen over gating the EAS cheatsheet, which serves the dev audience more than the buyer — gating it too is optional, same component). One component, one MailerLite form + welcome automation, done. Success metric: subscribers/week from weshipit.today — a number that is exactly zero today. _Skills: `lead-magnets`, `signup`. Tools: MailerLite._
+
+**Move 3 — Ladder the ask (Weeks 3–8).** Every content page gets a stage-appropriate CTA instead of a uniform "book a call": glossary/tool page → checklist download; checklist thank-you page → "want us to run it on your codebase? €10K Kickstart" + consulting link; podcast page → newsletter + audit; service pages keep the direct Cal.com CTA. This is the site's conversion architecture fixed in one pass — apply the hero rule (what it is → who it's for → offer) to `/audit`, `/react-native-testing`, and `/consulting` while touching them. _Skills: `cro`, `copywriting`, `site-architecture`._
+
+**Move 4 — Qualify the call before it's booked (Weeks 5–8).** Add 3–4 questions to the Cal.com booking form (app in production? team size? monthly users? what's breaking?). Two payoffs: David walks into every call pre-briefed (less founder time per lead), and unqualified leads get routed to the book/bootcamp/checklist instead of a 60-minute slot. _Skills: `signup`, `prospecting` qualification patterns. Tools: Cal.com custom questions — zero new infra._
+
+**Move 5 — Turn the 48h onboarding into a public asset (Q2).** Document the client onboarding — day 0 to first merged PR — as a page ("How we start") with a real (anonymized) timeline. It's the single most differentiated claim on the site and currently lives in one hero sentence. Doubles as sales enablement and referral material. _Skills: `onboarding`, `sales-enablement`._
+
+**Move 6 — Product-side activation: fix the buried funnels (Q2–Q3).** When the book/bootcamp relaunch happens (§8), activation is: landing page per product on weshipit.today, checkout without a call (Stripe/Gumroad — pattern already exists for the Growth tier), and the workshop platform's certification-share loop (LinkedIn cert + Twitter prompt — already built) used as the designed "aha → share" moment. _Skills: `paywalls`, `launch`._
+
+### 90-day activation moves
+
+| Weeks | Ship                                                                                                       |
+| ----- | ---------------------------------------------------------------------------------------------------------- |
+| 1–2   | Mailchimp → MailerLite migration complete; Mailchimp cancelled                                             |
+| 2–4   | Capture component live on tools + glossary + podcast pages; checklist asset written; welcome automation on |
+| 3–8   | CTA ladder across content pages; hero rule applied to `/audit`, `/react-native-testing`, `/consulting`     |
+| 5–8   | Cal.com qualification questions live                                                                       |
+| 9–12  | First capture-to-call data reviewed; "How we start" page drafted                                           |
+
+### 12-month outlook
+
+- **Q1:** list on MailerLite; capture exists; baseline subscribers/week and visitor→call rate measured for the first time.
+- **Q2:** CTA ladder converting; qualified-call rate up; "How we start" live.
+- **Q3:** product funnels (book/bootcamp) converting without calls; certification share-loop active.
+- **Q4:** activation instrumented end-to-end: visitor → subscriber → call → client, each step with a number.
+
+### Skills + tools
+
+- **Skills:** `lead-magnets`, `signup`, `cro`, `copywriting`, `onboarding`, `site-architecture`
+- **Tools:** **MailerLite** (forms, automations, API — all email work here and in §6), Cal.com custom questions, Vercel Analytics events from §4
+
+---
+
+## 6. Retention
+
+_Do converted people stay and deepen? Two retention surfaces here: retainer clients (where retention = revenue floor) and the email list (where retention = the launch audience for everything in §8). A services business with pause-anytime pricing lives or dies on the first one._
+
+### Current state
+
+Client retention is pure high-touch: Slack SLAs by tier (24h/12h/1h), weekly or daily calls, David's personal quality. It evidently works — but it's invisible (no artifact a client can forward to their CEO) and unmeasured (no record of why clients pause or leave, no tracking of retainer lifetime). List retention doesn't exist yet: the davidl.fr newsletter has no stated cadence, and there are no automations. Nothing is broken; nothing is built.
+
+### The plan
+
+**Move 1 — The monthly client recap (Q1, ~30 min/client/month).** One email per client per month: what shipped, hours used, measurable impact (crash rate, release cadence), what's next. This is retention _and_ expansion in one artifact — it's forwardable to the client's CEO/investors, it justifies the invoice before anyone questions it, and it surfaces upsell moments ("we're consistently at 40/40 hours — Growth tier?") without a sales conversation. Template once, fill monthly. _Skills: `sales-enablement`, `emails`. Tools: MailerLite or plain email — the artifact matters, not the tool._
+
+**Move 2 — Welcome + nurture sequence on MailerLite (Q1, after §5 capture ships).** One simple funnel, exactly what MailerLite is for: checklist download → welcome email (the checklist + who we are) → 3 education emails over 2 weeks (each solving one stability problem, drawn from glossary/podcast material) → soft pitch (audit or book). Write once, runs forever. _Skills: `emails`. Tools: MailerLite automations._
+
+**Move 3 — The monthly digest (Q1–Q4, ~1h/month).** One recurring newsletter assembled from what already ships anyway: the new podcast episode, 1–2 new/updated tools from the directory, one stability tip, one FR-corner line for the solopreneur audience (or split lists later if it grows). Cadence beats craft — this is the heartbeat that keeps the list warm for launches (§8). _Skills: `emails`, repurposing from §4 Move 5._
+
+**Move 4 — Paused ≠ churned (Q2).** Pause-anytime is a selling point; make it a retention loop. Tag paused clients as a segment, send a personal check-in at day 60 ("here's what changed in RN since we paused — new arch migration deadline, etc."), and log the reason every pause/end happens. Six months of reasons = the churn insight this business has never had. _Skills: `churn-prevention` (lightweight application)._
+
+**Move 5 — Alumni and community: consolidate, don't expand (Q2, one afternoon).** Kill the dead Slack invite link (it actively hurts). Pick the one place community lives — realistically the newsletter + workshop platform — and route bootcamp alumni (400+ historical) there once via a "we moved" note. No new community-building commitment: at 4h/week it would be the first thing to rot. _Skills: none needed — a decision, not a program._
+
+### 90-day retention moves
+
+| Weeks | Ship                                                                     |
+| ----- | ------------------------------------------------------------------------ |
+| 3–4   | Client recap template written; first recaps sent to all active retainers |
+| 5–8   | Welcome + nurture sequence live on MailerLite                            |
+| 6–8   | First monthly digest sent; recurring calendar slot booked                |
+| 9–12  | Pause-reason log started; dead Slack link removed                        |
+
+### 12-month outlook
+
+- **Q1:** recaps + welcome sequence + digest all running.
+- **Q2:** pause/churn reasons logged; alumni routed to the list.
+- **Q3:** retainer lifetime and pause-rate known for the first time; digest open rate steady.
+- **Q4:** retention data feeds pricing (§8): if average retainer lifetime is 12+ months, annual pre-pay becomes offerable with confidence.
+
+### Skills + tools
+
+- **Skills:** `emails`, `churn-prevention`, `sales-enablement`
+- **Tools:** MailerLite (sequence + digest + segments), a pause-reason log (Notion table is enough)
+
+---
+
+## 7. Referral
+
+_Referrals are already the #1 known client source ("referrals… I don't really know") — yet nothing in the business is designed to produce them. This section makes the accidental channel deliberate, without turning it into a program that needs managing._
+
+### Current state
+
+Word-of-mouth happens organically off David's reputation and client satisfaction. There is no ask, no moment, no incentive, no tracking. Meanwhile three referral loops are already _built_ but dormant: the workshop certification share (LinkedIn cert + Twitter prompt), the `api/feedback.ts` + Prismic feedback machinery, and a 25-person podcast guest network whose episodes mostly get shared once. On the other side of the table, David is himself an affiliate (Incubateur) — he knows exactly how this mechanic works when done well.
+
+### The plan
+
+**Move 1 — Install the ask at the strongest moment (Q1, zero infra).** The monthly client recap (§6 Move 1) creates a recurring high-satisfaction moment. Once a quarter, the recap ends with one line: _"Know a CTO whose React Native app is fighting them? An intro is the biggest compliment we can get."_ No portal, no tracking codes — a sentence in an email that already ships. Track manually: intros received, in the same Notion log as pause reasons.
+
+**Move 2 — Systematic testimonial + case-study harvest (Q1–Q2).** The feedback API and Prismic feedback type exist; use them. After every audit delivery and at every recap containing a win, request a 2-line testimonial (or capture the quote already sitting in Slack, with permission). Goal: 6 fresh testimonials and **2 written case studies** in 6 months — the case studies double as the sales material scored 2/5 in §3, and each one is inherently a referral artifact (clients share stories they star in). _Skills: `customer-research` (voice-of-customer capture), `sales-enablement`._
+
+**Move 3 — Make podcast guests referrers, not just guests (Q1, folds into §4 Move 5).** Every episode gets a share kit sent to the guest: 2 quote cards, 1 clip, pre-written post text. Guests with enterprise followings sharing to their networks is the highest-quality referral traffic this business can get, and it costs a template. _Skills: `social`, `co-marketing`._
+
+**Move 4 — Wake the certification loop (Q2, ships with bootcamp relaunch in §8).** The workshop platform already prompts LinkedIn certification + Twitter share. When the bootcamp relaunches, this loop is the built-in referral engine for the product side: every completing student broadcasts the certification to exactly the audience that buys the book/bootcamp. Make sure the cert links back to a live landing page, not the freelance-era one.
+
+**Move 5 — Own-affiliate program: deliberately deferred to Q4.** Gumroad supports affiliates natively, and the relaunched book could have ambassadors (bootcamp alumni are the obvious pool). But an affiliate program before the product funnel is proven converts nobody and adds management load. Decision gate: book/bootcamp relaunch shows ≥ 30 organic sales — then flip on Gumroad affiliates at 30% for alumni. _Skills: `referrals` — full program design only at the gate._
+
+### 90-day referral moves
+
+| Weeks | Ship                                                                              |
+| ----- | --------------------------------------------------------------------------------- |
+| 3–4   | Testimonial request folded into audit-delivery + recap workflow                   |
+| 5–8   | Guest share kit template; sent for next new episode + top 3 back-catalog episodes |
+| 9–12  | First quarterly referral ask ships in recaps; first case study drafted            |
+
+### 12-month outlook
+
+- **Q1:** ask installed; harvest running; guest kits shipping.
+- **Q2:** 2 case studies live; certification loop live with relaunch.
+- **Q3:** intros/quarter tracked — referral becomes a measured channel for the first time.
+- **Q4:** affiliate-program gate evaluated on product sales data.
+
+### Skills + tools
+
+- **Skills:** `referrals` (Q4 gate), `sales-enablement`, `co-marketing`, `customer-research`, `social`
+- **Tools:** existing `api/feedback.ts` + Prismic feedback type, Gumroad affiliates (Q4), Notion intro log
+
+---
+
+## 8. Revenue
+
+_What we charge, who pays, and how it compounds. The thesis from §2: retainers are the floor, hours-decoupled revenue is the growth line. The good news: the product ladder mostly exists — it's scattered, unpriced, or unlaunched._
+
+### Current state
+
+Revenue today (€5–15K/mo) is ~90% founder-hours: retainers (€2.5K/€5K/mo), the €10K Kickstart audit, paid consulting, plus early affiliate income. Pricing is public and well-structured with real scarcity (spots left), but there's no unit-economics view: retainer lifetime, effective (vs listed) prices, and affiliate commission totals are all unmeasured. The productized assets — book (Gumroad), bootcamp, workshop platform, 9 courses, Maestro flat-fee — either live on the freelance-era site or have never been launched _at_ an audience.
+
+### The plan
+
+**Move 1 — Define the product ladder and put every rung on weshipit.today (Q1–Q2).** One coherent ladder, each rung a designed step to the next:
+
+| Rung                 | Offer                                         | Price                   | Status                       |
+| -------------------- | --------------------------------------------- | ----------------------- | ---------------------------- |
+| Free                 | Stability checklist, tools, glossary, podcast | €0                      | Live (capture added in §5)   |
+| Product              | Road to React Native book                     | ~€29–49 [TBD]           | Exists on Gumroad — relaunch |
+| Product              | Bootcamp / workshop (self-serve or cohort)    | ~€299–990 [TBD]         | Platform built — relaunch    |
+| Service, productized | Maestro testing setup (flat fee)              | Price it publicly [TBD] | Page live, price hidden      |
+| Service, productized | Kickstart audit                               | €10,000                 | Live                         |
+| Service, recurring   | Essential / Growth retainers                  | €2.5K / €5K/mo          | Live                         |
+| Service, premium     | Enterprise                                    | Custom                  | Live                         |
+
+The rule per the brand-voice memo: every rung's page says what it is and who it's for before the price. _Skills: `pricing`, `offers`._
+
+**Move 2 — Relaunch the book, then the bootcamp, as actual launches (Q2 and Q3).** These products have never been launched at an owned audience — there wasn't one. By Q2 there is (list from §5, digest from §6). Each relaunch: refreshed landing page on weshipit.today, price test, launch sequence to the list, podcast mention, guest-network share, Product Hunt for the book. This is also the experiment that answers "can this business sell products?" with real data before any bigger productization bet. _Skills: `launch`, `emails`, `pricing`._
+
+**Move 3 — Monetize the tools directory with partner/affiliate links (Q2–Q3).** 49 tools; a meaningful share run partner or affiliate programs. Where a program exists and the tool genuinely belongs in the directory, add the affiliate link + disclosure. This is the Incubateur mechanic applied to traffic already owned — zero new content, recurring commission potential. Guardrail: editorial integrity first — no tool enters or ranks better because of a commission (that honesty is the brand, per §2). _Skills: `co-marketing`. Tools: existing directory fixtures — one field per tool._
+
+**Move 4 — Push the affiliate line at cohort windows (Q1–Q4).** The Incubateur cluster converts year-round, but cohort/masterclass windows are the spikes: a dedicated email to the FR segment + a temporary FR banner each window. Measure per-window revenue — this number decides how much more FR affiliate content deserves building in year 2.
+
+**Move 5 — Retainer pricing review, gated on data (Q4).** Don't touch what works blind. After two quarters of §6 data (retainer lifetime, pause reasons, hours utilization): consider annual pre-pay (if lifetime > 12mo), an Essential price bump for new clients (if demand > capacity), and publishing the Maestro flat fee. _Skills: `pricing`._
+
+### Unit economics (to fill — top open decisions in §13)
+
+| Metric                  | Value       | Note                                        |
+| ----------------------- | ----------- | ------------------------------------------- |
+| ARPC (retainer avg)     | ~€2.5–5K/mo | Listed; effective avg [TBD from Stripe]     |
+| Retainer lifetime       | [TBD]       | Start measuring now (§6 Move 4)             |
+| Blended CAC             | [TBD]       | Unknowable until §4 Move 1 attribution runs |
+| Affiliate commission/mo | [TBD]       | Systeme.io dashboard has this today         |
+| Product revenue/mo      | ~€0         | The line this plan exists to grow           |
+
+### 12-month outlook
+
+- **Q1:** ladder defined; all offers on weshipit.today; affiliate window playbook ready.
+- **Q2:** book relaunched — first product revenue on the books; directory partner links live.
+- **Q3:** bootcamp relaunched; product + affiliate ≥ 10% of revenue.
+- **Q4:** pricing review with real data; product + affiliate target: **20–25% of monthly revenue, hours-decoupled.**
+
+### Skills + tools
+
+- **Skills:** `pricing`, `offers`, `launch`, `paywalls`, `co-marketing`
+- **Tools:** Stripe (effective-price pull), Gumroad, Systeme.io dashboard, MailerLite launch sequences
+
+**Open at approval:** book + bootcamp price points; bootcamp format (self-serve vs cohort) — carried to §13 open decisions.
+
+---
+
+## 9. 90-day roadmap
+
+_Owners are honest about who actually does the work: "Claude" = agentic sessions in the weshipit.today repo that David reviews and merges — that's how the plan fits in < 4h/week of founder time._
+
+### Weeks 1–2 — Unblock
+
+| Move                                                                                            | Stage         | Owner                               |
+| ----------------------------------------------------------------------------------------------- | ------------- | ----------------------------------- |
+| Merge + deploy SEO branches 003–008; request re-indexing                                        | Acquisition   | David (merge), Claude (verify)      |
+| Wire conversion events: Cal.com clicks, affiliate clicks, form submits, newsletter signups      | Acquisition   | Claude (code), David (review)       |
+| Mailchimp → MailerLite migration; domain auth; rewrite `api/newsletter.ts`; cancel Mailchimp    | Activation    | David (accounts), Claude (code)     |
+| Janitor pass: retire `home.tsx`/`qr.tsx`/`devtools.tsx`, dead Slack invite, legacy Gumroad link | Cross-cutting | Claude                              |
+| Pull baseline numbers: Systeme.io affiliate revenue, Stripe effective prices, GSC traffic       | Revenue       | David (15 min of dashboard exports) |
+
+### Weeks 3–4 — Foundation
+
+| Move                                                                                                  | Stage       | Owner                                                      |
+| ----------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------- |
+| Stability Checklist written; capture component on tools/glossary/podcast pages; welcome automation on | Activation  | David (checklist content), Claude (component + MailerLite) |
+| `/temoignages-incubateur-solopreneur` spoke live                                                      | Acquisition | Claude (draft), David (approve)                            |
+| First podcast transcripts published (top 5 episodes)                                                  | Acquisition | Claude (pipeline)                                          |
+| Client recap template; first recaps to all active retainers                                           | Retention   | David                                                      |
+| Testimonial ask folded into audit-delivery + recap workflow                                           | Referral    | David                                                      |
+| Directory submissions + This Week in React pitch (one afternoon)                                      | Acquisition | David                                                      |
+
+### Weeks 5–8 — Velocity
+
+| Move                                                                                           | Stage                | Owner                                         |
+| ---------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------- |
+| `/incubateur-solopreneur` hub pillar live                                                      | Acquisition          | Claude (draft), David (approve)               |
+| Audit-cluster keyword map + first spoke page                                                   | Acquisition          | Claude (`claude-seo` agents), David (approve) |
+| Guest-outreach note to all 25 past podcast guests + share-kit template                         | Acquisition/Referral | David (send), Claude (kit)                    |
+| CTA ladder across content pages; hero rule on `/audit`, `/react-native-testing`, `/consulting` | Activation           | Claude (code), David (copy review)            |
+| Cal.com qualification questions live                                                           | Activation           | David (10 min)                                |
+| Nurture sequence (welcome + 3 education + soft pitch) live on MailerLite                       | Retention            | Claude (drafts), David (edit)                 |
+| First monthly digest sent; recurring slot booked                                               | Retention            | David (~1h)                                   |
+| Product-ladder pricing decisions: book, bootcamp format, Maestro public fee                    | Revenue              | **David — decision gate**                     |
+
+### Weeks 9–12 — Compound
+
+| Move                                                                                         | Stage                | Owner                                    |
+| -------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------- |
+| Second audit-cluster spoke + first "vs" comparison page                                      | Acquisition          | Claude, David (approve)                  |
+| Podcast clip cadence running (1 clip/episode to X + LinkedIn)                                | Acquisition          | Claude/VA-candidate task                 |
+| First monthly attribution review: booked calls by source, subscribers/week, affiliate clicks | Cross-cutting        | David + Claude (30 min ritual)           |
+| Quarterly referral ask ships in recaps                                                       | Referral             | David                                    |
+| First case study drafted from a recap win                                                    | Referral/Revenue     | Claude (draft), client (approval)        |
+| Pause-reason log started; "How we start" page drafted                                        | Retention/Activation | David / Claude                           |
+| Book relaunch prep: refreshed landing page on weshipit.today, launch sequence drafted        | Revenue              | Claude (build), David (price + go/no-go) |
+
+**Founder-hours reality check:** David's recurring load lands at ~3–4h/week (recaps, digest, approvals, one monthly review) plus two one-time spikes (migration accounts setup, pricing decision gate). Everything else is agentic execution + review.
+
+---
+
+## 10. 12-month outlook
+
+### Framing: budget method and growth pattern
+
+**Budget method:** neither standard method applies cleanly to a bootstrapped services duo — the real budget is **founder attention (≤ 4h/week) + ~€150–250/mo tooling** (MailerLite adds ~€20/mo; everything else is already paid). The goal-based logic still anchors the plan: the 12-month goal is not an ARR number but a **revenue-mix number — 20–25% of monthly revenue hours-decoupled (product + affiliate) by Q4**, against ~5–10% today. The one budget unlock is self-funded: if product revenue appears in Q2, ~€300–500/mo buys a VA/editor for podcast post-production and repurposing — the highest-leverage euro this business can spend.
+
+**Growth pattern:** layered S-curves, stated honestly. The **services curve** is near its ceiling by design (~€25K/mo max for 2 people) — the plan keeps it flat-to-gently-up, not growing. The **affiliate curve** is early and growing. The **product curve** is being staged now (list → launch → iterate) and produces step-functions, not smooth lines: expect two visible steps (book relaunch, bootcamp relaunch) with plateaus between. No hockey stick is promised; what compounds is the audience asset under all three curves.
+
+### Q1 — Months 1–3 (the 90-day roadmap, §9)
+
+**Funding state:** bootstrapped, €0 new spend. **Focus:** measurement, consolidation, capture.
+
+**Outcomes:** attribution live; MailerLite migrated; capture + welcome sequence + digest running; Incubateur cluster complete; recaps + testimonial harvest running; pricing decision gate passed.
+
+**KPI targets:** subscribers/week > 0 and trending (baseline was zero); 100% of conversion events instrumented; 25 guest share-kits sent; 2+ testimonials collected.
+
+**S-curves:** services flat (by design); affiliate maturing; product curve staged, not yet launched.
+
+### Q2 — Months 4–6
+
+**Funding state:** bootstrapped; optional VA unlock (~€300–500/mo) if cash flow allows. **Focus:** first product revenue + the davidl.fr consolidation.
+
+**Outcomes:** **book relaunch shipped** (landing page on weshipit.today, launch sequence, Product Hunt); davidl.fr repointed (audience-only, offers redirect, cross-links live); audit + vs clusters published; LinkedIn cadence running; directory partner links live; 2 case studies published; "How we start" page live.
+
+**KPI targets:** first ≥ 30 book sales (also the §7 affiliate-program gate); 1–2 audit conversations sourced from podcast guest network; list ≥ 3× Q1 size; booked-calls-by-source known monthly.
+
+**S-curves:** product curve ignites (step one); services still flat; affiliate steady.
+
+### Q3 — Months 7–9
+
+**Funding state:** bootstrapped + VA. **Focus:** bootcamp relaunch + cluster maturation.
+
+**Outcomes:** **bootcamp relaunch** in the chosen format (decision gate from §8); certification share-loop live; RN clusters at Incubateur-cluster maturity (hub + spokes + tracked conversions); transcripts fully indexed; second Incubateur cohort window executed with per-window revenue measured.
+
+**KPI targets:** product + affiliate ≥ 10% of monthly revenue; retainer lifetime + pause rate known; organic-sourced booked calls ≥ referral-sourced (first time measurable).
+
+**S-curves:** product curve steps again (bootcamp); affiliate curve tested for headroom; services curve — pricing review being prepared with data.
+
+### Q4 — Months 10–12
+
+**Funding state:** bootstrapped; VA continued if product revenue holds. **Focus:** pricing with data + doubling down on what the year proved.
+
+**Outcomes:** retainer pricing review executed (annual pre-pay / Essential bump / Maestro public fee — per §8 Move 5); Gumroad affiliate program gate evaluated; year-in-review attribution report — blended CAC per channel named for the first time; year-2 plan drafted from real numbers, not vibes.
+
+**KPI targets:** **product + affiliate = 20–25% of monthly revenue**; total monthly revenue ≥ high end of today's band (€15K+) without added founder delivery hours; list is the #1 launch channel by attributable revenue.
+
+**S-curves:** the year's verdict gets written here — whichever curve (product vs affiliate) showed the steeper slope gets year-2's investment; the other gets maintenance mode. That decision is the whole point of instrumenting everything in Q1.
+
+---
+
+## 11. Marketing operations stack
+
+### The thesis
+
+The plan asks a two-person delivery team to run acquisition, activation, retention, referral, and revenue programs on < 4h/week of founder time. That's only coherent because the execution layer is agentic: David is a developer, the marketing site is code, and the repo already proves the model — **the June–July 2026 SEO sprint generated 8 scoped implementation plans via the `/improve` skill and shipped them through Claude Code sessions, taking the technical-SEO backlog from audit to merged in under two weeks, with David's role limited to review and merge.** Section 9's owner column ("Claude" on most rows) is this thesis operationalized: David makes decisions and touches clients; agents produce drafts, pages, components, and analyses.
+
+### Skills mapped to AARRR stages (as used in this plan)
+
+| Stage         | Primary skills                                                                                                                          | Supporting skills                                    |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Acquisition   | `programmatic-seo`, `seo-audit`, `ai-seo`, `analytics`                                                                                  | `directory-submissions`, `social`, `video`, `schema` |
+| Activation    | `lead-magnets`, `signup`, `cro`                                                                                                         | `copywriting`, `site-architecture`, `onboarding`     |
+| Retention     | `emails`, `churn-prevention`                                                                                                            | `sales-enablement` (client recaps)                   |
+| Referral      | `referrals` (Q4 gate), `co-marketing`                                                                                                   | `customer-research`, `social`                        |
+| Revenue       | `pricing`, `offers`, `launch`                                                                                                           | `paywalls`, `co-marketing`                           |
+| Cross-cutting | `product-marketing` (run in Q1 — creates `.agents/product-marketing.md` so every future session shares the §2 frame), `marketing-ideas` | `marketing-psychology`, `copy-editing`               |
+
+### Tooling mapped to stages
+
+| Stage       | Wired today                                                                                                  | To wire (Q1)                                                           | Not needed yet                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------ |
+| Acquisition | Vercel Analytics + Speed Insights, `claude-seo` agent suite (cluster/technical/geo/content), GitHub, Prismic | GSC API review ritual; conversion events                               | Ahrefs/DataForSEO paid tiers, ad platforms |
+| Activation  | Cal.com (custom questions), Airtable/Notion forms                                                            | **MailerLite** (forms + API), capture component                        | —                                          |
+| Retention   | —                                                                                                            | MailerLite automations + segments; Notion pause-log                    | Customer.io-class tooling (overkill)       |
+| Referral    | `api/feedback.ts` + Prismic feedback type, workshop certification loop                                       | Notion intro log                                                       | Dub/Rewardful (until Q4 gate)              |
+| Revenue     | Stripe, Gumroad, Systeme.io affiliate dashboard                                                              | Monthly numbers pull (Stripe + Systeme.io) into the attribution review | —                                          |
+
+Honest state note: there is no GA4, no Ahrefs subscription, no email-platform MCP. The plan doesn't pretend otherwise — everything routes through what's wired (Vercel Analytics events, GSC, MailerLite's simple API) and the repo itself.
+
+### The concrete example (already happened)
+
+The `/improve` → 8 plans → merged-branches sprint is the proof, but so is **this plan's own production**: the research phase swept every route, fixture, and strategy doc in the monorepo in minutes — including surfacing that davidl.fr held the business's only email list and its entire product inventory, which reframed the strategy. That discovery cost zero founder hours.
+
+### Capability unlocks (bootstrapped tiers, not funding rounds)
+
+| Tier                           | Trigger                                          | Adds                                                                                                             |
+| ------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| **Today**                      | —                                                | David + Claude Code sessions + wired tools above; all §9 work executes here                                      |
+| **+ VA/editor (~€300–500/mo)** | First product revenue (Q2)                       | Podcast post-production, clips, repurposing, digest assembly — the repetitive 20% agents can't finish end-to-end |
+| **+ Reinvestment (~€1–2K/mo)** | Product + affiliate ≥ 20% of revenue (Q4/year 2) | Paid amplification of proven funnels, an SEO data subscription, possibly a fractional editor for the FR arm      |
+
+### Team model (RACI, adapted to a duo)
+
+| Function                                           | Strategy (accountable) | Execution                                 |
+| -------------------------------------------------- | ---------------------- | ----------------------------------------- |
+| Growth/demand (SEO, clusters, attribution)         | David                  | Claude Code sessions; `claude-seo` agents |
+| Product marketing (positioning, launches, pricing) | David                  | Claude drafts; David decides              |
+| Content/trust (podcast, digest, socials)           | David                  | Claude/VA repurposing; David records      |
+| Client marketing (recaps, testimonials, referrals) | David                  | Template-driven; David sends              |
+| Delivery (unchanged)                               | Matthys + David        | —                                         |
+
+No marketing hire is recommended in the next 12 months. The first human addition is the VA/editor — an execution role, not a strategist: strategy is already owned by a π-shaped founder; what's scarce is repetitive-production capacity.
+
+---
+
+## 12. Tactical idea bank
+
+_Sections 4–8 prescribe what's being done. This section maps what's possible — all 139 ideas from the `marketing-ideas` library, cross-referenced to AARRR with a weshipit-specific status — so nothing gets rediscovered in month 8, and everything skipped was skipped on purpose._
+
+**Status legend:** **Live** = already running before this plan (acknowledged) · **Now (Q1)** = in the 90-day plan · **Q2** / **Q3+** / **Q4+** = layered in later · **Skip** = doesn't fit, rationale given.
+
+### 12.1 Acquisition ideas
+
+| #     | Idea                                                                                                               | Status            | weshipit note                                                                                                       |
+| ----- | ------------------------------------------------------------------------------------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1     | Easy Keyword Ranking                                                                                               | Now               | Audit cluster targets low-difficulty commercial keywords ("react native audit")                                     |
+| 2     | SEO Audit                                                                                                          | Now               | June sprint done; repeat quarterly via `claude-seo` agents                                                          |
+| 3     | Glossary Marketing                                                                                                 | Live              | 100+ terms shipped; maintain via Prismic                                                                            |
+| 4     | Programmatic SEO                                                                                                   | Live (partial)    | Tools/glossary are template systems; tool-category pages Q3                                                         |
+| 5     | Content Repurposing                                                                                                | Now               | Transcripts, clips, quote cards from 25 episodes                                                                    |
+| 6     | Proprietary Data Content                                                                                           | Q3+               | **"State of React Native Stability" report from anonymized audit data — strongest untapped idea in the bank**       |
+| 7     | Internal Linking                                                                                                   | Now               | Cluster link matrices per the Incubateur doc pattern                                                                |
+| 8     | Content Refreshing                                                                                                 | Q3+               | Refresh top tool pages + old episodes annually                                                                      |
+| 9     | Knowledge Base SEO                                                                                                 | Skip              | No help-docs product                                                                                                |
+| 10    | Parasite SEO                                                                                                       | Q2                | Republish transcripts/essays on dev.to/Medium with canonicals                                                       |
+| 11    | Competitor Comparison Pages                                                                                        | Q2                | "vs agency," "vs hiring in-house," "vs freelancer" for RN services                                                  |
+| 12    | Marketing Jiu-Jitsu                                                                                                | Q2                | Position against agency lock-in contracts inside the vs pages                                                       |
+| 13    | Competitive Ad Research                                                                                            | Skip              | No paid layer                                                                                                       |
+| 14    | Side Projects                                                                                                      | Live              | davidl.fr assets, EAS cheatsheet; no new ones this year                                                             |
+| 15    | Engineering as Marketing                                                                                           | Live              | The tools directory IS this; scanner idea parked at #21                                                             |
+| 16    | Importers as Marketing                                                                                             | Skip              | SaaS-specific                                                                                                       |
+| 17    | Quiz Marketing                                                                                                     | Q4+               | "How healthy is your RN app?" quiz feeding the checklist funnel                                                     |
+| 18    | Calculator Marketing                                                                                               | Q4+               | "Cost of app instability" calculator (crash rate × users × LTV)                                                     |
+| 19    | Chrome Extensions                                                                                                  | Skip              | Category misfit                                                                                                     |
+| 20    | Microsites                                                                                                         | Skip              | **Anti-plan** — consolidating surfaces, not adding them                                                             |
+| 21    | Scanners                                                                                                           | Q4+               | RN dependency/health scanner — high fit, pure capacity question                                                     |
+| 22    | Public APIs                                                                                                        | Skip              | Nothing to expose yet                                                                                               |
+| 23–34 | All Paid Ads (podcast, pre-targeting, FB, IG, X, LinkedIn, Reddit, Quora, Google, YouTube, retargeting, messenger) | Skip              | No budget, no attribution baseline; revisit year 2 at reinvestment tier — LinkedIn Ads (#28) is the first candidate |
+| 35    | Community Marketing                                                                                                | Skip              | **Anti-plan** — consolidate to newsletter + workshop (§6 Move 5); no new community at 4h/wk                         |
+| 36    | Quora Marketing                                                                                                    | Q3+               | Light; answers repurposed from existing content only                                                                |
+| 37    | Reddit Keyword Research                                                                                            | Q3+               | Mine r/reactnative for cluster keywords                                                                             |
+| 38    | Reddit Marketing                                                                                                   | Q3+               | Value-first in r/reactnative, low cadence                                                                           |
+| 39    | LinkedIn Audience                                                                                                  | Q2                | §4 Move 6 — where the buying ICP scrolls                                                                            |
+| 40    | Instagram Audience                                                                                                 | Skip              | Audience isn't there                                                                                                |
+| 41    | X Audience                                                                                                         | Live              | @flexbox\_; maintain via repurposing                                                                                |
+| 42    | Short Form Video                                                                                                   | Q2                | Podcast clips (VA task)                                                                                             |
+| 43    | Engagement Pods                                                                                                    | Skip              | Off-brand                                                                                                           |
+| 44    | Comment Marketing                                                                                                  | Q3+               | Light; RN threads on X/LinkedIn                                                                                     |
+| 49    | Monthly Newsletters                                                                                                | Now               | §6 digest (acquisition use: capture + swap currency)                                                                |
+| 54    | Affiliate Discovery via Backlinks                                                                                  | Q3+               | Find sites linking to RN agencies → outreach                                                                        |
+| 55    | Influencer Whitelisting                                                                                            | Skip              | Paid                                                                                                                |
+| 56    | Reseller Programs                                                                                                  | Skip              | Services don't resell                                                                                               |
+| 57    | Expert Networks                                                                                                    | Q3+               | David on expert platforms for audit leads                                                                           |
+| 58    | Newsletter Swaps                                                                                                   | Q2                | This Week in React pitch; FR solopreneur newsletter swaps                                                           |
+| 59    | Article Quotes (HARO)                                                                                              | Q2                | RN/mobile queries only; 15 min/week cap                                                                             |
+| 60    | Pixel Sharing                                                                                                      | Skip              | Paid                                                                                                                |
+| 61    | Shared Slack Channels                                                                                              | Q3+               | Partner channels with complementary agencies (design/backend)                                                       |
+| 63    | Integration Marketing                                                                                              | Skip              | No product integrations yet                                                                                         |
+| 64    | Community Sponsorship                                                                                              | Q3+               | Sponsor an RN meetup/newsletter — small € when reinvestment unlocks                                                 |
+| 65    | Live Webinars                                                                                                      | Q3+               | "RN stability workshop" webinar feeding the audit                                                                   |
+| 66    | Virtual Summits                                                                                                    | Skip              | Capacity                                                                                                            |
+| 67    | Roadshows                                                                                                          | Skip              | Capacity                                                                                                            |
+| 68    | Local Meetups                                                                                                      | Q3+               | Opportunistic (Lille history); speak, don't organize                                                                |
+| 69    | Meetup Sponsorship                                                                                                 | Q4+               | Small €                                                                                                             |
+| 70    | Conference Speaking                                                                                                | Now               | Already speakable (talks page live); accept 2–3/yr, each feeds clips + audit CTA                                    |
+| 71    | Own Conferences                                                                                                    | Skip              | Capacity                                                                                                            |
+| 72    | Conference Sponsorship                                                                                             | Skip              | Budget                                                                                                              |
+| 73    | Media Acquisitions                                                                                                 | Skip              | Stage                                                                                                               |
+| 74    | Press Coverage                                                                                                     | Q3+               | FR tech press: podcast + enterprise RN adoption angle                                                               |
+| 75    | Fundraising PR                                                                                                     | Skip              | Not raising, by design                                                                                              |
+| 76    | Documentaries                                                                                                      | Skip              | Stage                                                                                                               |
+| 77    | Black Friday Promotions                                                                                            | Q4                | Book/bootcamp seasonal promo                                                                                        |
+| 78    | Product Hunt Launch                                                                                                | Q2                | Book relaunch                                                                                                       |
+| 79    | Early-Access Referrals                                                                                             | Q3                | Bootcamp cohort early access (cross-cuts Referral)                                                                  |
+| 80    | New Year Promotions                                                                                                | Q1 (seasonal)     | "New year, stable app" angle if timing fits                                                                         |
+| 81    | Early Access Pricing                                                                                               | Q3                | Bootcamp relaunch pricing                                                                                           |
+| 82    | Product Hunt Alternatives                                                                                          | Q2                | With the book launch                                                                                                |
+| 83    | Twitter Giveaways                                                                                                  | Skip              | Off-brand                                                                                                           |
+| 84    | Giveaways                                                                                                          | Skip              | Off-brand                                                                                                           |
+| 85    | Vacation Giveaways                                                                                                 | Skip              | Off-brand                                                                                                           |
+| 86    | Lifetime Deals                                                                                                     | Skip              | Damages the ladder and retainer LTV logic                                                                           |
+| 87    | Powered By Marketing                                                                                               | Skip              | No embeddable product                                                                                               |
+| 88    | Free Migrations                                                                                                    | Skip              | SaaS-specific — but the "we take over from your agency" angle lives in #11/#12                                      |
+| 89    | Contract Buyouts                                                                                                   | Q4+               | Adapt: credit first month for teams exiting an agency contract; test once vs pages rank                             |
+| 97    | Playlists as Marketing                                                                                             | Skip              | Category misfit                                                                                                     |
+| 98    | Template Marketing                                                                                                 | Live              | Starters directory; extend with Maestro flow templates Q3                                                           |
+| 99    | Graphic Novel Marketing                                                                                            | Skip              | Off-brand                                                                                                           |
+| 100   | Promo Videos                                                                                                       | Q4+               | Only post-VA                                                                                                        |
+| 101   | Industry Interviews                                                                                                | Live              | The podcast IS this                                                                                                 |
+| 102   | Social Screenshots                                                                                                 | Q2                | Quote cards from episodes/testimonials                                                                              |
+| 103   | Online Courses                                                                                                     | Q3                | Bootcamp relaunch                                                                                                   |
+| 104   | Book Marketing                                                                                                     | Q2                | Road to React Native relaunch — shifted early because the book exists                                               |
+| 105   | Annual Reports                                                                                                     | Q4                | Merge with #6 (State of RN Stability)                                                                               |
+| 106   | End of Year Wraps                                                                                                  | Q4                | RN ecosystem year wrap + own year-in-review                                                                         |
+| 107   | Podcasts (own-hosted)                                                                                              | Live              | 25 episodes; hold the ~1.5/mo cadence                                                                               |
+| 108   | Changelogs                                                                                                         | Skip              | Revisit when products have release cadence                                                                          |
+| 109   | Public Demos                                                                                                       | Now               | Maestro YAML demo live; add "How we start" (§5)                                                                     |
+| 110   | Awards as Marketing                                                                                                | Skip              | Stage                                                                                                               |
+| 111   | Challenges as Marketing                                                                                            | Q3+               | Workshop challenges already exist; public RN challenge tied to bootcamp launch                                      |
+| 112   | Reality TV Marketing                                                                                               | Skip              | Off-brand                                                                                                           |
+| 113   | Controversy as Marketing                                                                                           | Skip              | Honesty yes; manufactured controversy no                                                                            |
+| 114   | Moneyball Marketing                                                                                                | Now               | The plan's attribution-first operating system (cross-cuts all stages)                                               |
+| 115   | Curation as Marketing                                                                                              | Live              | Tools directory + resources; monetized via §8 Move 3                                                                |
+| 116   | Grants as Marketing                                                                                                | Skip              | Category misfit                                                                                                     |
+| 117   | Product Competitions                                                                                               | Q3+               | Fold into #111                                                                                                      |
+| 118   | Cameo Marketing                                                                                                    | Skip              | Off-brand                                                                                                           |
+| 119   | OOH Advertising                                                                                                    | Skip              | Budget/stage                                                                                                        |
+| 120   | Marketing Stunts                                                                                                   | Skip              | Off-brand                                                                                                           |
+| 121   | Guerrilla Marketing                                                                                                | Skip              | Off-brand                                                                                                           |
+| 122   | Humor Marketing                                                                                                    | Skip (as program) | David's natural tone suffices; don't systematize                                                                    |
+| 123   | Open Source as Marketing                                                                                           | Live              | GitHub presence + sponsors link                                                                                     |
+| 125   | App Marketplaces                                                                                                   | Skip              | No marketplace product                                                                                              |
+| 126   | YouTube Reviews                                                                                                    | Skip              | Passive-YouTube decision (§4)                                                                                       |
+| 127   | YouTube Channel                                                                                                    | Live (passive)    | Repurposing only, per §4 decision                                                                                   |
+| 128   | Source Platforms                                                                                                   | Skip              | B2B-SaaS-specific                                                                                                   |
+| 129   | Review Sites                                                                                                       | Q2                | Clutch/Trustpilot studio profile; affiliate side already runs avis pages                                            |
+| 130   | Live Audio                                                                                                         | Skip              | Capacity                                                                                                            |
+| 131   | International Expansion                                                                                            | Live (structural) | EN/FR bilingual already; no third market this year                                                                  |
+| 133   | Investor Marketing                                                                                                 | Skip              | Not raising                                                                                                         |
+| 138   | Podcast Tours                                                                                                      | Q2                | David as guest — 10 prior appearances prove the motion                                                              |
+
+### 12.2 Activation ideas
+
+| #   | Idea                    | Status | weshipit note                                                     |
+| --- | ----------------------- | ------ | ----------------------------------------------------------------- |
+| 47  | Founder Welcome Email   | Now    | Plain-text welcome from David after checklist download            |
+| 48  | Dynamic Email Capture   | Now    | Checklist capture, context-aware per page type (tools vs podcast) |
+| 51  | Onboarding Emails       | Now    | Nurture sequence (§6 Move 2)                                      |
+| 90  | One-Click Registration  | Skip   | No signup product                                                 |
+| 91  | In-App Upsells          | Skip   | No app — the analog is the recap upsell (§6 Move 1)               |
+| 95  | Concierge Setup         | Live   | The 48h onboarding IS concierge; document it (§5 Move 5)          |
+| 96  | Onboarding Optimization | Now    | Cal.com qualification questions                                   |
+| 124 | App Store Optimization  | Skip   | No own app                                                        |
+
+### 12.3 Retention ideas
+
+| #   | Idea                    | Status        | weshipit note                                                         |
+| --- | ----------------------- | ------------- | --------------------------------------------------------------------- |
+| 45  | Mistake Email Marketing | Opportunistic | If a mistake happens, own it in the digest — on-brand honesty         |
+| 46  | Reactivation Emails     | Q2            | Paused-client day-60 check-in (§6 Move 4)                             |
+| 50  | Inbox Placement         | Now           | SPF/DKIM at MailerLite migration                                      |
+| 52  | Win-back Emails         | Q2            | Ended-client quarterly note with RN-ecosystem hook                    |
+| 53  | Trial Reactivation      | Skip          | No trial                                                              |
+| 94  | Offboarding Flows       | Q2            | Pause-reason capture                                                  |
+| 134 | Certifications          | Q3            | Workshop LinkedIn cert relaunches with bootcamp (cross-cuts Referral) |
+| 135 | Support as Marketing    | Live          | Tiered Slack SLA is the product; quote it in case studies             |
+
+### 12.4 Referral ideas
+
+| #   | Idea                   | Status   | weshipit note                                                                                    |
+| --- | ---------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| 62  | Affiliate Program      | Now / Q4 | As affiliate: Incubateur live, directory partner links Q2. Own program: Q4 gate (≥30 book sales) |
+| 79  | Early-Access Referrals | Q3       | Bootcamp cohort                                                                                  |
+| 92  | Newsletter Referrals   | Q4+      | Only if list growth justifies tooling                                                            |
+| 93  | Viral Loops            | Q2       | Certification share loop (already built — wake it)                                               |
+| 137 | Two-Sided Referrals    | Q3+      | Intro incentive (audit discount both sides) only if the organic ask underperforms                |
+
+### 12.5 Revenue ideas
+
+| #   | Idea               | Status | weshipit note                                  |
+| --- | ------------------ | ------ | ---------------------------------------------- |
+| 91  | In-App Upsells     | Skip   | See 12.2 — recap upsell is the services analog |
+| 132 | Price Localization | Skip   | EUR works for both markets                     |
+
+### 12.6 Cross-cutting / developer-specific
+
+| #   | Idea                 | Status | weshipit note                                                    |
+| --- | -------------------- | ------ | ---------------------------------------------------------------- |
+| 114 | Moneyball Marketing  | Now    | Attribution review ritual (§9, weeks 9–12)                       |
+| 139 | Customer Language    | Now    | Testimonial/VoC harvest (§7 Move 2) feeds all copy               |
+| 136 | Developer Relations  | Live   | The entire business is DevRel-shaped: podcast, OSS, tools, talks |
+| 117 | Product Competitions | Q3+    | See #111                                                         |
+
+### Idea-bank summary
+
+- **Live before this plan: ~16 ideas** — the strongest validation that the asset base is real; the plan acknowledges rather than reinvents them.
+- **Now (Q1): ~15** · **Q2: ~17** · **Q3+: ~20** · **Q4+: ~10** · **Skip: ~60** (of which 15 are paid-ads-related, ~15 category misfits, ~10 off-brand, ~5 anti-plan by thesis, remainder stage/capacity).
+- The 90-day plan touches ~14% of the tactical surface; the full year ~40%. Correct for a 4h/week bootstrapped operation — the bank's job is ensuring the other 60% was skipped **on purpose, with written reasons**, not never considered.
+- First promotions when capacity appears: **#6 State of RN Stability report** and **#21 RN health scanner** — both compound the "stability experts" category claim.
+
+---
+
+## 13. Measurement, RACI, open decisions, appendix
+
+### North-star metric (proposed)
+
+**Hours-decoupled revenue share** = (product + affiliate revenue) ÷ total monthly revenue. Today ~5–10%; target 20–25% by month 12. It's the one number that captures the plan's thesis — if it grows while total revenue holds, the business is escaping the hours trap; if total revenue grows but this doesn't, we've just gotten busier.
+
+### Leading indicators by AARRR stage
+
+| Stage       | Leading indicators                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| Acquisition | Booked calls by source (monthly); organic clicks on money pages + clusters (GSC); affiliate-link clicks |
+| Activation  | Subscribers/week from weshipit.today; visitor→subscriber rate on tools/glossary; qualified-call share   |
+| Retention   | Active retainers + pause rate; digest open rate; retainer lifetime (rolling)                            |
+| Referral    | Intros/quarter (Notion log); testimonials collected; guest share-kit usage                              |
+| Revenue     | Product sales/mo; affiliate €/mo (Systeme.io); revenue mix % (north star)                               |
+
+### Review cadence
+
+- **Weekly (~15 min, solo):** glance at conversion events + subscribers; nothing else.
+- **Monthly (~30 min, David + Claude session):** the attribution review — booked calls by source, list growth, affiliate revenue, one decision recorded.
+- **Quarterly:** plan recalibration against §10; the two Q-gates (pricing decisions, affiliate-program gate) get decided here.
+
+### RACI
+
+| Domain                                       | R               | A     | C                              | I       |
+| -------------------------------------------- | --------------- | ----- | ------------------------------ | ------- |
+| Strategic plan + brand voice                 | David           | David | Claude (drafts)                | Matthys |
+| Site implementation (capture, events, pages) | Claude          | David | Matthys                        | —       |
+| SEO clusters (EN + FR)                       | Claude          | David | `claude-seo` agents            | —       |
+| Lifecycle email (MailerLite)                 | Claude (drafts) | David | —                              | —       |
+| Podcast + socials                            | David           | David | VA (Q2+), Claude (repurposing) | —       |
+| Client recaps, referral asks, testimonials   | David           | David | —                              | Matthys |
+| Pricing + product launches                   | David           | David | Claude (analysis)              | Matthys |
+| Delivery (unchanged)                         | Matthys + David | David | —                              | —       |
+
+### Open decisions blocking the plan (ranked by impact)
+
+1. **Blended CAC / attribution — unknown.** Nothing structural can be optimized until §4 Move 1 runs for ~60 days. Highest-impact unknown; every revenue projection depends on it.
+2. **Book + bootcamp pricing and bootcamp format (self-serve vs cohort).** Blocks the Q2/Q3 relaunches — the David decision gate in §9 weeks 5–8.
+3. **Mailchimp list size + health.** Determines whether Q2 launches go to a real audience or Q1 must over-invest in capture. 10 minutes in the Mailchimp dashboard answers it.
+4. **Incubateur affiliate commission % and per-window revenue.** Sits in the Systeme.io dashboard today; decides how much the FR arm deserves in year 2.
+5. **Organic traffic baseline** (GSC + Vercel Analytics on tools/glossary). Determines expected capture volume; also answers whether the SEO moat is already producing.
+6. **VA/editor budget trigger** (~€300–500/mo at first product revenue). A pre-commitment now avoids re-litigating in Q2.
+7. **Retreat and workshops** — kept out of this plan's scope (episodic, founder-heavy). Confirm they stay opportunistic rather than marketed.
+
+### Appendix — deep-dive references
+
+- Plan artifacts: this document (`docs/marketing/plan.md`); the research record and per-section drafts live in the fCMO working folder — ask David
+- In-repo strategy docs: the Incubateur cluster strategy + tracking plan (`docs/seo/`), 8 executed SEO improvement plans (`plans/`), podcast workflow guide (`docs/`)
+- Dashboards: Vercel Analytics, GSC, Stripe, Gumroad, Systeme.io (affiliate), MailerLite (post-migration)
+- Voice + positioning source: §2 of this plan; recommend running `product-marketing` in Q1 to persist it as `.agents/product-marketing.md` in the repo
+- Tooling note: most skills named in §4–8 and §11 are installed and verified. A few (`cro`, `copywriting`, `copy-editing`, `sales-enablement`, `referrals`, `ab-testing`) are part of the wider marketing-skills library and may need installing when first used — fall back to the underlying tactic if absent.
+
+---
+
+_weshipit.today Marketing Plan v1. Prepared with David Leuliette, 2026-07-10. For team review and discussion._


### PR DESCRIPTION
## What

Adds the finalized 12-month marketing plan (`docs/marketing/plan.md`, ~10.7K words, 13 sections, AARRR-structured), built and approved section-by-section on 2026-07-09/10.

## TL;DR of the plan

- **North star:** hours-decoupled revenue (products + affiliate) from ~5–10% → **20–25% of monthly revenue** in 12 months, on < 4h/week founder time and €0 new spend.
- **Bet 1 — Consolidate:** davidl.fr becomes the audience layer, weshipit.today the commercial layer, the FR affiliate cluster is the playbook both follow.
- **Bet 2 — Connective tissue:** Mailchimp → MailerLite migration, Stability Checklist capture on tools/glossary/podcast pages, welcome sequence + monthly digest.
- **Bet 3 — Relaunch, don't build:** book (Q2) and bootcamp (Q3) launched at the owned audience for the first time; tools directory gets partner links; Incubateur cluster completed.
- **Week 1–2 actions:** conversion-event instrumentation, ESP migration, merge waiting SEO branches, janitor pass.

Section 13 lists the open decisions (top: blended CAC/attribution — unknown until events run ~60 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)